### PR TITLE
Enabled EBS automation termination

### DIFF
--- a/AWS-Kubernetes-Lab.yaml
+++ b/AWS-Kubernetes-Lab.yaml
@@ -25,7 +25,7 @@ Resources:
                 Ebs:
                   VolumeType: gp2
                   VolumeSize: '30'
-                  DeleteOnTermination: 'false'
+                  DeleteOnTermination: 'true'
                   Encrypted: 'true'
       UserData:
         Fn::Base64: !Sub |
@@ -109,7 +109,7 @@ Resources:
                 Ebs:
                   VolumeType: gp2
                   VolumeSize: '30'
-                  DeleteOnTermination: 'false'
+                  DeleteOnTermination: 'true'
                   Encrypted: 'true'    
       UserData:
         Fn::Base64: !Sub |
@@ -163,7 +163,7 @@ Resources:
           Ebs:
             VolumeType: gp2
             VolumeSize: '30'
-            DeleteOnTermination: 'false'
+            DeleteOnTermination: 'true'
             Encrypted: 'true'
       UserData:
         Fn::Base64: !Sub |


### PR DESCRIPTION
Enabling EBS automatic termination, so that when users delete the CloudFormation stack, the EBS volumes are deleted with it. Previously, the EBS volumes we're not being terminated automatically.